### PR TITLE
Bug Fix: block percentage can be less than 1 but not less than 0

### DIFF
--- a/realmines-plugin/src/main/java/joserodpt/realmines/plugin/gui/MineItemsGUI.java
+++ b/realmines-plugin/src/main/java/joserodpt/realmines/plugin/gui/MineItemsGUI.java
@@ -497,7 +497,7 @@ public class MineItemsGUI {
                     this.editPercentage(p, a, current);
                 }
 
-                if (d < 1D) {
+                if (d < 0D) {
                     TranslatableLine.SYSTEM_INPUT_PERCENTAGE_ERROR_GREATER.send(p);
                     this.editPercentage(p, a, current);
                     return;


### PR DESCRIPTION
Right now the block percentage can't be less than 1. But it should be able to.